### PR TITLE
I've updated the README.md file with a new "Observability" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,85 @@ flux get images all
   kubectl delete namespace personal-site
   ```
 
+## Observability (Prometheus & Grafana)
+
+This project now includes a GitOps-managed observability stack using Prometheus for metrics collection and Grafana for visualization. The setup is deployed via the `kube-prometheus-stack` Helm chart, managed by FluxCD.
+
+### How it Works
+
+FluxCD monitors the `kubernetes/` directory (specifically looking at `kubernetes/kustomization.yaml`, which then includes `kubernetes/observability/kustomization.yaml`). When changes are pushed to this repository, FluxCD will:
+
+1.  Apply the `HelmRepository` resource to make the `prometheus-community` Helm chart repository available.
+2.  Apply the `HelmRelease` resource for `kube-prometheus-stack`, which installs Prometheus, Grafana, Alertmanager, and various metrics exporters into the `monitoring` namespace.
+3.  Apply the `sealed-grafana-admin-credentials.yaml` (once created by you) to configure the Grafana admin password.
+4.  Grafana is configured with a sidecar to automatically discover and import dashboards provided as ConfigMaps with the label `grafana_dashboard: "1"` in the `monitoring` namespace. (Note: The actual creation of these dashboard ConfigMaps is a pending task from the previous automated work session).
+
+### User Setup Steps
+
+There are a couple of manual steps you need to perform for the initial setup:
+
+1.  **Set Grafana Admin Password:**
+    A manifest for an unsealed Grafana admin secret is provided at `kubernetes/observability/grafana-admin-credentials-unsealed.yaml`. You **must** edit this file to set a strong password:
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: grafana-admin-credentials
+      namespace: monitoring
+    type: Opaque
+    stringData:
+      adminPassword: "YOUR_STRONG_GRAFANA_PASSWORD" # <-- REPLACE THIS
+      adminUser: admin
+    ```
+    Then, use your `kubeseal` utility to encrypt this secret and save it as `kubernetes/observability/sealed-grafana-admin-credentials.yaml`.
+    Example command:
+    ```bash
+    kubeseal --format=yaml < kubernetes/observability/grafana-admin-credentials-unsealed.yaml > kubernetes/observability/sealed-grafana-admin-credentials.yaml
+    ```
+    Commit the resulting `sealed-grafana-admin-credentials.yaml` file to the repository. The unsealed version should **not** be committed.
+
+2.  **Verify FluxCD Kustomization:**
+    This setup introduced a top-level Kustomization at `kubernetes/kustomization.yaml` which includes the `./base` and `./observability` paths.
+    Ensure your FluxCD bootstrap configuration (the `Kustomization` resource that syncs *this* `personal-site-infra` repository) is pointing to this `kubernetes/kustomization.yaml` file, or that it otherwise includes `kubernetes/observability/kustomization.yaml` in its `spec.path`. If Flux was originally bootstrapped to only look at `./kubernetes/base` or specific overlay paths, you might need to update its configuration to include the new observability components.
+
+### Accessing Grafana
+
+Once deployed, you can access Grafana as follows:
+
+*   **Username:** `admin`
+*   **Password:** The strong password you set in the `grafana-admin-credentials` secret.
+
+To access the Grafana UI, you can use port-forwarding:
+
+```bash
+kubectl port-forward svc/kube-prometheus-stack-grafana -n monitoring 9090:80
+```
+
+Then, open your browser and navigate to `http://localhost:9090`.
+
+*(Note: The service name for Grafana is typically `<helm-release-name>-grafana`. Since our HelmRelease is named `kube-prometheus-stack`, the service is `kube-prometheus-stack-grafana`.)*
+
+### Available Dashboards (Pending Implementation)
+
+The following dashboards are intended to be automatically imported into Grafana once their ConfigMap definitions are added (this was a pending task from the previous automated work session and still needs to be implemented):
+
+*   **Kubernetes Cluster Overview:** General health and resource usage of the Kubernetes cluster.
+*   **Kubernetes Node Overview:** Detailed metrics for individual nodes.
+*   **FluxCD Control Plane:** Health and status of FluxCD components and reconciliations.
+
+### Troubleshooting
+
+*   **Check Pod Status:** To see if Prometheus, Grafana, and other components are running:
+    ```bash
+    kubectl get pods -n monitoring
+    ```
+*   **Check FluxCD Logs:** If the observability components are not deploying as expected, check the FluxCD controller logs:
+    ```bash
+    kubectl logs -n flux-system -l app=source-controller
+    kubectl logs -n flux-system -l app=kustomize-controller
+    kubectl logs -n flux-system -l app=helm-controller
+    ```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Include the base application components
+  - ./base
+  # Include the new observability stack
+  - ./observability
+  # Add other paths like overlays/blue or overlays/green here
+  # if this kustomization is intended to be the single entry point for Flux
+  # e.g.,
+  # - ./overlays/blue
+  # - ./overlays/green

--- a/kubernetes/observability/grafana-admin-credentials-unsealed.yaml
+++ b/kubernetes/observability/grafana-admin-credentials-unsealed.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin-credentials
+  namespace: monitoring # This secret needs to be in the same namespace as Grafana
+type: Opaque
+stringData:
+  adminPassword: "YOUR_STRONG_GRAFANA_PASSWORD" # Replace with a strong password
+  adminUser: admin # Default Grafana admin user

--- a/kubernetes/observability/helmrelease-kube-prometheus-stack.yaml
+++ b/kubernetes/observability/helmrelease-kube-prometheus-stack.yaml
@@ -1,0 +1,46 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: flux-system # This should be flux-system to be managed by Flux
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      version: "56.6.0" # Use a specific version for predictability
+  releaseName: kube-prometheus-stack
+  targetNamespace: monitoring # Deploy the actual stack into the 'monitoring' namespace
+  install:
+    createNamespace: true # Create the 'monitoring' namespace if it doesn't exist
+  values:
+    grafana:
+      adminPasswordFromSecret:
+        name: grafana-admin-credentials
+        key: adminPassword
+      persistence:
+        enabled: true
+        size: 10Gi
+      # Necessary for dashboard ConfigMap discovery
+      sidecar:
+        dashboards:
+          enabled: true
+          searchNamespace: "ALL" # Or specify "monitoring" if dashboards are only there
+    prometheus:
+      prometheusSpec:
+        persistence:
+          enabled: true
+          volumeSize: 10Gi
+        retention: 10d # Adjust retention as needed
+        # Rule and ServiceMonitor discovery from all namespaces
+        ruleSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
+
+# Note: We will create a separate secret for grafana.adminPassword
+# and then update this HelmRelease to reference it.
+# For now, a placeholder value is used to create the file structure.
+# Actual Grafana password will be managed via a SealedSecret.

--- a/kubernetes/observability/helmrepository-prometheus-community.yaml
+++ b/kubernetes/observability/helmrepository-prometheus-community.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts

--- a/kubernetes/observability/kustomization.yaml
+++ b/kubernetes/observability/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: flux-system # Kustomizations themselves are often managed in flux-system
+
+resources:
+  - helmrepository-prometheus-community.yaml
+  - helmrelease-kube-prometheus-stack.yaml
+  # The user will create this sealed secret.
+  # Flux will apply it once it's present in the directory.
+  - sealed-grafana-admin-credentials.yaml


### PR DESCRIPTION
This new section provides details on setting up, configuring, and using the Prometheus and Grafana observability stack.

Here's what the documentation covers:
- An overview of the Prometheus & Grafana stack.
- How FluxCD manages these components.
- Essential setup steps for you:
    - Sealing the Grafana admin password.
    - Verifying FluxCD Kustomization for the observability path.
- Instructions for accessing Grafana via port-forwarding.
- A note on the pending implementation of dashboard ConfigMaps.
- Basic troubleshooting commands for checking pod status and Flux logs.